### PR TITLE
The VASCO DIGIPASS SecureClick does have a replaceable battery

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ The responsiveness of this device when pairing and authenticating is much better
 
 The BLE pairing experience instructs you to enter a code "printed on the device".  The Feitian MultiPass has such a code, this device does not, but '0000' worked.
 
-The unit is sealed and the battery is not replacable. I am told it should last up to five years, which is a reasonable lifetime, but necessitates a backup in my opinion.
+The unit uses an included CR2012 battery, which should last at least two years when used for maximum of 10 authentications per day. The battery is replacable, and instructions for doing so are in the manual.
 
 These do not appear to be available for purchase in the United States.
 


### PR DESCRIPTION
See page 10 of the manual which can be found at https://www.vasco.com/images/DP-SecureClick-User-Manual_tcm42-54919.pdf
The two year minimum lifespan is listed here https://www.vasco.com/products/two-factor-authenticators/hardware/one-button/digipass-secureclick.html

(Full disclosure: I work for VASCO)