### PR TITLE
Update Yubico Authenticator download page

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ The key I used sucessfully in my Chromebook at that time hasn't worked for sever
 
 *4C Photo Credit: AGL*
 
-I'll review these together as they are essentially the same device in different packaging.  These have the same solid U2F implementation as the U2F-only key, plus a bunch of additional features.   My favorite is the TOTP applet, accessible though the [Yubico Authenticator](https://www.yubico.com/support/knowledge-base/categories/articles/yubico-authenticator-download/) application for Linux, Windows and Mac.  I like having hardware TOTP key storage and backup, as I discuss in more detail below, so this is a killer feature for me.
+I'll review these together as they are essentially the same device in different packaging.  These have the same solid U2F implementation as the U2F-only key, plus a bunch of additional features.   My favorite is the TOTP applet, accessible though the [Yubico Authenticator](https://www.yubico.com/products/services-software/download/yubico-authenticator/) application for Linux, Windows and Mac.  I like having hardware TOTP key storage and backup, as I discuss in more detail below, so this is a killer feature for me.
 
 I'm also interested in trying out the PGP features of the key for code signing on GitHub, though I otherwise try to avoid PGP.
 


### PR DESCRIPTION
https://www.yubico.com/support/knowledge-base/categories/articles/yubico-authenticator-download/ returns a 404. 

https://www.yubico.com/products/services-software/download/yubico-authenticator/ looks like the correct download location at the moment.